### PR TITLE
Filter on bucket key. 

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,8 +28,8 @@ exports.handler = function(config, event, context, callback) {
   if (config.mappings) {
     _.some(config.mappings, function(item) {
       if (item.type === eventType ||
-          ((config.S3 && item.bucket === config.S3.srcBucket)
-              && ( !item.keyPrefix || config.S3.srcKey.startsWith(item.keyPrefix) ))) {
+          ((config.S3 && item.bucket === config.S3.srcBucket) &&
+          (!item.keyPrefix || config.S3.srcKey.startsWith(item.keyPrefix)))) {
         currentMapping = item;
         console.log('Selected mapping for S3 event:', item);
         if (item.hasOwnProperty('processors')) {

--- a/index.js
+++ b/index.js
@@ -27,9 +27,9 @@ exports.handler = function(config, event, context, callback) {
   var currentMapping;
   if (config.mappings) {
     _.some(config.mappings, function(item) {
-      // Added a keyPrefix option
       if (item.type === eventType ||
-          ((config.S3 && item.bucket === config.S3.srcBucket) && ( !item.keyPrefix || config.S3.srcKey.startsWith(item.keyPrefix) ))) {
+          ((config.S3 && item.bucket === config.S3.srcBucket)
+              && ( !item.keyPrefix || config.S3.srcKey.startsWith(item.keyPrefix) ))) {
         currentMapping = item;
         console.log('Selected mapping for S3 event:', item);
         if (item.hasOwnProperty('processors')) {
@@ -51,6 +51,11 @@ exports.handler = function(config, event, context, callback) {
   var tasks = [];
   var processor;
   _.some(taskNames, function(taskName) {
+    if (_.isFunction(taskName)) {
+      tasks.push(taskName);
+      return false;
+    }
+
     try {
       processor = require('./handlers/' + taskName);
     } catch (err) {

--- a/index.js
+++ b/index.js
@@ -27,8 +27,9 @@ exports.handler = function(config, event, context, callback) {
   var currentMapping;
   if (config.mappings) {
     _.some(config.mappings, function(item) {
+      // Added a keyPrefix option
       if (item.type === eventType ||
-          (config.S3 && item.bucket === config.S3.srcBucket)) {
+          ((config.S3 && item.bucket === config.S3.srcBucket) && ( !item.keyPrefix || config.S3.srcKey.startsWith(item.keyPrefix) ))) {
         currentMapping = item;
         console.log('Selected mapping for S3 event:', item);
         if (item.hasOwnProperty('processors')) {
@@ -50,11 +51,6 @@ exports.handler = function(config, event, context, callback) {
   var tasks = [];
   var processor;
   _.some(taskNames, function(taskName) {
-    if (_.isFunction(taskName)) {
-      tasks.push(taskName);
-      return false;
-    }
-
     try {
       processor = require('./handlers/' + taskName);
     } catch (err) {


### PR DESCRIPTION
Added an option to include keyPrefix in the mapping section.  This allows for processing a consolidated log bucket.  I'm not sure where it is best to document in the ReadMe but if you point to the section I can add documentation there. 

Sample Config:
      {
        bucket: acme-conslidated-logs',
        keyPrefix: 'cloudwatch-lambda',
        processors: [
          'decompressGzip',
          'parseJson',
          'formatCloudwatchLogs',
          'shipElasticsearch'
        ],
        elasticsearch: {
          index: 'lambda'
        },
        dateField: 'date'
      }