### PR TITLE
Add support for http auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /coverage
 /node_modules
+/package-lock.json

--- a/handlers/shipElasticsearch.js
+++ b/handlers/shipElasticsearch.js
@@ -7,6 +7,10 @@ exports.process = function(config) {
     host: config.elasticsearch.host
   };
 
+  if (config.elasticsearch.httpAuth) {
+    esConfig.httpAuth = config.elasticsearch.httpAuth;
+  }
+
   if (config.elasticsearch.useAWS) {
     esConfig.connectionClass = require('http-aws-es');
     esConfig.amazonES = {

--- a/index.js
+++ b/index.js
@@ -46,7 +46,12 @@ exports.handler = function(config, event, context, callback) {
     return callback(null, 'Event did not match any mappings.');
   }
 
-  console.log('Running ' + taskNames.length + ' handlers with config:', config);
+  
+  _config = JSON.parse(JSON.stringify(config)) // Deep clone object to prevent modifying the real config.httpAuth key
+  if (_config.elasticsearch.httpAuth) {
+    _config.elasticsearch.httpAuth = "*****"
+  }
+  console.log('Running ' + taskNames.length + ' handlers with _config:', _config);
   var tasks = [];
   var processor;
   _.some(taskNames, function(taskName) {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "aws-sdk": "^2.3.18",
     "csv-parse": "^1.1.1",
-    "elasticsearch": "^11.0.1",
+    "elasticsearch": "^13.3.1",
     "http-aws-es": "tphummel/http-aws-es",
     "lodash": "^4.13.1"
   },

--- a/test/shipElasticsearch.spec.js
+++ b/test/shipElasticsearch.spec.js
@@ -12,6 +12,33 @@ describe('handler/shipElasticsearch.js', function() {
       handler = require('../handlers/shipElasticsearch');
     });
 
+    it('should allow http auth',
+      function(done) {
+        var config = {
+          elasticsearch: {
+            httpAuth: 'asdf:wut',
+            index: 'index',
+            type: 'type'
+          },
+          data: [
+            {
+              value: '1'
+            },
+            {
+              value: '2'
+            }
+          ],
+          test: 'test'
+        };
+        var es = require('elasticsearch');
+        es.Client = function(config) {
+          assert.strictEqual(config.httpAuth, 'asdf:wut',
+            'httpAuth param provided');
+          done();
+        };
+        handler.process(config);
+      });
+
     it('should split data by the maxChunkSize',
       function(done) {
         var passVal1 = false;
@@ -19,6 +46,7 @@ describe('handler/shipElasticsearch.js', function() {
         var es = require('elasticsearch');
         es.Client = function(config) {
           assert.strictEqual(config.host, 'http://mock', 'host param provided');
+          assert.strictEqual(config.httpAuth, undefined, 'httpAuth param not provided');
           return {
             bulk: function(params, callback) {
               if (params.body[1].value === '1') {


### PR DESCRIPTION
Resolves #16 

Redaction necesary, or user/pass shows up in log. After redacting:

```
/aws/lambda/cloudwatch_logs_to_elasticsearch 2017/09/26/[$LATEST]cde5dc28309c4228b2b265c1cea26e9f 2017-09-26T18:12:08.322Z      35574970-a2e6-11e7-a601-6df19095e394    Running 5 handlers with _config: { elasticsearch:
   { host: 'https://es.redact.com:9200',
     httpAuth: '*****',
     index: 'logstash-2017-09-26',
     type: 'test' },
  data: 'snip',
  type: 'CloudWatch',
  processors: [ 'formatCloudwatchLogs', 'shipElasticsearch' ] }
```