### PR TITLE
Fix http-aws-es dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "aws-sdk": "^2.3.18",
     "csv-parse": "^1.1.1",
     "elasticsearch": "^11.0.1",
-    "http-aws-es": "tphummel/http-aws-es",
+    "http-aws-es": "^2.0.5",
     "lodash": "^4.13.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -4,13 +4,14 @@
   "description": "AWS Lambda script for shipping data from S3 or other cloud data sources to data stores, like Elasticsearch",
   "main": "index.js",
   "dependencies": {
-    "aws-sdk": "^2.3.18",
+    "aws-sdk": "^2.83.0",
     "csv-parse": "^1.1.1",
-    "elasticsearch": "^11.0.1",
+    "elasticsearch": "^13.2.0",
     "http-aws-es": "^2.0.5",
-    "lodash": "^4.13.1"
+    "lodash": "^4.17.5"
   },
   "devDependencies": {
+    "babel-eslint": "^8.2.3",
     "coveralls": "^2.11.9",
     "eslint": "^2.11.1",
     "eslint-config-google": "^0.6.0",


### PR DESCRIPTION
The `tphummel/http-aws-es` fork has been removed, since the issue related to that fork was resolved. See: https://github.com/TheDeveloper/http-aws-es/pull/1
