### PR TITLE
Update convertString to handle values with double quotes

### DIFF
--- a/handlers/convertString.js
+++ b/handlers/convertString.js
@@ -7,9 +7,12 @@ exports.process = function(config) {
   }
 
   config.data = _.map(config.data, function(datum) {
+    var escapeChar = config.string && config.string.escapeChar ?
+      config.string.escapeChar : '\'';
+
     var parts = _.map(datum, function(value, key) {
       key = String(key).replace('-', '_').replace(/\W/g, '');
-      value = String(value).replace(/\n/g, ' ');
+      value = String(value).replace(/\n/g, ' ').replace(/"/g, escapeChar);
       return key + '="' + value + '"';
     });
 

--- a/test/convertString.spec.js
+++ b/test/convertString.spec.js
@@ -58,5 +58,42 @@ describe('handler/convertString.js', function() {
             done();
           });
       });
+
+    it('should escape double quote characters',
+      function(done) {
+        var config = {
+          data: [{test: 'this is "a" test.'}],
+          setting: true
+        };
+        dataString = "test=\"this is 'a' test.\"\n";
+        handler.process(config)
+          .then(function(result) {
+            assert.ok(result.hasOwnProperty('setting'),
+              'process returns config object');
+            assert.equal(result.data, dataString,
+              'converted to string with prefix and suffix successfully');
+            done();
+          });
+      });
+
+    it('should support a configurable escape character',
+      function(done) {
+        var config = {
+          data: [{test: 'this is "a" test.'}],
+          setting: true,
+          string: {
+            escapeChar: 'x'
+          }
+        };
+        dataString = "test=\"this is xax test.\"\n";
+        handler.process(config)
+          .then(function(result) {
+            assert.ok(result.hasOwnProperty('setting'),
+              'process returns config object');
+            assert.equal(result.data, dataString,
+              'converted to string with prefix and suffix successfully');
+            done();
+          });
+      });
   });
 });


### PR DESCRIPTION
Currently the `convertString` handler builds a string like `key="value"`. However `value` can contain double quote characters, which can cause problems with some parsers.

This PR changes `convertString` to replace all double quotes with another character, either by default a single quote or another character specified through configuration.